### PR TITLE
Ensuring the proper screen is taken into account for window positioning.

### DIFF
--- a/main.gd
+++ b/main.gd
@@ -22,7 +22,7 @@ var isEnd = false
 func _ready():
     # Save
     if not FileAccess.file_exists(savePath):
-        var screen = DisplayServer.screen_get_size()
+        var screen = DisplayServer.screen_get_size(DisplayServer.MAIN_WINDOW_ID)
         var window = get_viewport().get_visible_rect().size
         get_window().position = Vector2((screen.x/2-window.x/2),(screen.y-window.y) - 20)
     load_data()


### PR DESCRIPTION
This fix ensures that Godot uses the same screen/monitor that it is spawning the app window into for positioning of the window. In the case of having 2 displays with different resolutions, it prevents the window from spawning beyond the extents of the lower-resolution screen.